### PR TITLE
Revert some Menendez changes to historic URLs

### DIFF
--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -798,18 +798,18 @@
     state: NJ
     class: 1
     party: Democrat
-    url: http://www.menendez.senate.gov/
+    url: http://menendez.senate.gov/
   - type: sen
     start: '2007-01-04'
     end: '2013-01-03'
     state: NJ
     class: 1
     party: Democrat
-    url: http://www.menendez.senate.gov/
+    url: http://menendez.senate.gov/
     address: 528 HART SENATE OFFICE BUILDING WASHINGTON DC 20510
     phone: 202-224-4744
     fax: 202-228-2197
-    contact_form: http://www.menendez.senate.gov/contact/
+    contact_form: http://menendez.senate.gov/contact/
     office: 528 Hart Senate Office Building
   - type: sen
     start: '2013-01-03'


### PR DESCRIPTION
This will clear https://github.com/unitedstates/congress-legislators/pull/279 for merge. It leaves the change to Menendez' current URL intact, while reverting his previous terms' URLs.
